### PR TITLE
Update test matrix to include Django 5.1 and Wagtail 6.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,9 @@ version = '1.1.7'
 description = 'A Block for Wagtail that lets users choose a Page/Document/URL/email/etc. as a link'
 readme = 'README.md'
 maintainers = [{ name = 'The Developer Society', email = 'studio@dev.ngo' }]
-requires-python = '>= 3.8'
+requires-python = '>= 3.9'
 dependencies = [
-    'Wagtail>=4.1',
+    'Wagtail>=5.2',
 ]
 classifiers = [
     'Intended Audience :: Developers',
@@ -14,15 +14,17 @@ classifiers = [
     'Operating System :: OS Independent',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Framework :: Django',
-    'Framework :: Django :: 3.2',
     'Framework :: Django :: 4.2',
     'Framework :: Django :: 5.0',
+    'Framework :: Django :: 5.1',
+    'Framework :: Wagtail',
+    'Framework :: Wagtail :: 5',
+    'Framework :: Wagtail :: 6',
 ]
 
 [project.urls]
@@ -37,7 +39,7 @@ include = ['wagtail_link_block*']
 
 [tool.ruff]
 line-length = 99
-target-version = 'py38'
+target-version = 'py39'
 
 [tool.ruff.lint]
 select = [

--- a/tox.ini
+++ b/tox.ini
@@ -2,22 +2,20 @@
 env_list =
     check
     lint
-    py{38,39,310,311}-django3.2-wagtail4.1
-    py{38,39,310,311,312}-django{3.2,4.2}-wagtail5.2
-    py{38,39,310,311,312}-django4.2-wagtail6.1
-    py{310,311,312}-django5.0-wagtail6.1
+    py{39,310,311,312}-django{4.2,5.0}-wagtail{5.2,6.2,6.3}
+    py{310,311,312}-django5.1-wagtail6.3
     coverage
 no_package = true
 
 [testenv]
 deps =
     -rrequirements/testing.txt
-    django3.2: Django>=3.2,<4.0
     django4.2: Django>=4.2,<5.0
     django5.0: Django>=5.0,<5.1
-    wagtail4.1: wagtail>=4.1,<4.2
+    django5.1: Django>=5.1,<5.2
     wagtail5.2: wagtail>=5.2,<5.3
-    wagtail6.1: wagtail>=6.1,<6.2
+    wagtail6.2: wagtail>=6.2,<6.3
+    wagtail6.3: wagtail>=6.3,<6.4
 allowlist_externals = make
 commands = make test
 package = editable

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 env_list =
     check
     lint
-    py{39,310,311,312}-django{4.2,5.0}-wagtail{5.2,6.2,6.3}
+    py39-django4.2-wagtail{5.2,6.2}
+    py{310,311,312}-django{4.2,5.0}-wagtail{5.2,6.2,6.3}
     py{310,311,312}-django5.1-wagtail6.3
     coverage
 no_package = true


### PR DESCRIPTION
- drops testing against python 3.8
- drop testing against Django 3.2 and Wagtail 4.1 and 4.2