### PR TITLE
Update supported Python/Django/Wagtail versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = 'README.md'
 maintainers = [{ name = 'The Developer Society', email = 'studio@dev.ngo' }]
 requires-python = '>= 3.10'
 dependencies = [
-    'Wagtail>=6.3',
+    'Wagtail>=7.0',
 ]
 license = 'BSD-3-Clause'
 classifiers = [
@@ -21,9 +21,8 @@ classifiers = [
     'Programming Language :: Python :: 3.14',
     'Framework :: Django',
     'Framework :: Django :: 4.2',
-    'Framework :: Django :: 5.1',
     'Framework :: Django :: 5.2',
-    'Framework :: Wagtail :: 6',
+    'Framework :: Django :: 6.0',
     'Framework :: Wagtail :: 7',
 ]
 
@@ -39,7 +38,7 @@ include = ['wagtail_link_block*']
 
 [tool.ruff]
 line-length = 99
-target-version = 'py39'
+target-version = 'py310'
 
 [tool.ruff.lint]
 select = [

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,5 +1,5 @@
 -r testing.txt
 
-bump-my-version==0.24.3
-tox==4.51.0
-tox-uv==1.33.4
+bump-my-version==1.3.0
+tox==4.53.1
+tox-uv==1.35.2

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,6 +1,6 @@
-build==1.2.1
-check-wheel-contents==0.6.0
-coverage==7.6.0
-pipdeptree==2.23.1
-ruff==0.5.5
+build==1.5.0
+check-wheel-contents==0.6.3
+coverage==7.14.0
+pipdeptree==2.35.2
+ruff==0.15.12
 twine==6.2.0

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,9 @@
 env_list =
     check
     lint
-    py{310,311,312}-django4.2-wagtail{6.3,7.0,7.1,7.2}
-    py{310,311,312,313}-django{5.1,5.2}-wagtail{6.3,7.0,7.1,7.2}
-    py314-django5.2-wagtail7.2
+    py{310,311,312}-django4.2-wagtail{7.0,7.3}
+    py{310,311,312,313}-django5.2-wagtail{7.0,7.3,7.4}
+    py{312,313,314}-django6.0-wagtail{7.3,7.4}
     coverage
 no_package = true
 
@@ -12,12 +12,11 @@ no_package = true
 deps =
     -rrequirements/testing.txt
     django4.2: Django>=4.2,<5.0
-    django5.1: Django>=5.1,<5.2
     django5.2: Django>=5.2,<5.3
-    wagtail6.3: wagtail>=6.3,<6.4
+    django6.0: Django>=6.0,<6.1
     wagtail7.0: wagtail>=7.0,<7.1
-    wagtail7.1: wagtail>=7.1,<7.2
-    wagtail7.2: wagtail>=7.2,<7.3
+    wagtail7.3: wagtail>=7.3,<7.4
+    wagtail7.4: wagtail>=7.4,<7.5
 allowlist_externals = make
 commands = make test
 package = editable


### PR DESCRIPTION
## Summary

Refresh the support matrix to match current Python, Django, and Wagtail release schedules (as of May 2026).

### Support range

| Axis | Before | After |
|---|---|---|
| Python | 3.10–3.14 | 3.10–3.14 (unchanged) |
| Django | 4.2, 5.1, 5.2 | 4.2, 5.2 LTS, 6.0 |
| Wagtail | ≥6.3 (6.3, 7.0–7.2 tested) | ≥7.0 (7.0 LTS, 7.3, 7.4 LTS tested) |

### Dropped
- **Django 5.1** — EOL December 2025.
- **Wagtail 6.3 LTS** — EOL May 2026.
- **Wagtail 7.1 / 7.2** — EOL May 2026.

### Added
- **Django 6.0** — released December 2025.
- **Wagtail 7.3** and **Wagtail 7.4 LTS**.

### Retained
- **Django 4.2** — kept because Wagtail 7.0 LTS (still in security support until Nov 2026) supports it.

### Other
- `[tool.ruff] target-version` corrected from `py39` to `py310` to match `requires-python`.
- Development dependencies (`ruff`, `coverage`, `build`, `check-wheel-contents`, `pipdeptree`, `bump-my-version`, `tox`, `tox-uv`) bumped to current releases.

## Test plan
- [x] `ruff check` and `ruff format --check` clean.
- [x] `tox -e py312-django4.2-wagtail7.0` — 34 tests pass.
- [x] `tox -e py312-django5.2-wagtail7.0` — 34 tests pass.
- [x] `tox -e py312-django5.2-wagtail7.4` — 34 tests pass.
- [x] `tox -e py312-django6.0-wagtail7.4` — 34 tests pass.
- [ ] CI runs the full expanded matrix on PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)